### PR TITLE
Option to not throw rest exceptions in Client.execute

### DIFF
--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -185,11 +185,14 @@ class Client {
             body != null &&
             body.isNotEmpty == true) {
           try {
-            responseBody = _useIsolate == true ? await processJson(body) : json.decode(body);
+            responseBody = _useIsolate == true
+                ? await processJson(body)
+                : json.decode(body);
           } catch (e) {
             _logger.warning('Expected a JSON body, but did not encounter one');
           }
-        } else if (contentType?.startsWith('text/') == true && body is List<int>) {
+        } else if (contentType?.startsWith('text/') == true &&
+            body is List<int>) {
           responseBody = utf8.decode(body);
         }
 
@@ -215,7 +218,8 @@ class Client {
             url: request.url,
           );
 
-          if (throwRestExceptions && (response.statusCode < 200 || response.statusCode >= 400)) {
+          if (throwRestExceptions &&
+              (response.statusCode < 200 || response.statusCode >= 400)) {
             throw RestException(
               message: exception != null
                   ? 'Error from server: ${exception}'


### PR DESCRIPTION
The standard functionality of this package is to throw a `RestException` for responses with a status code <200 or >= 400. This is fine for some applications, but in other cases it might be preferable to return the response anyway due to:
1. Control flow choices in the parent application (some people don't like using exceptions for flow)
2. Sometimes error responses come with bodies that contain more specific information about the error, that you might want. e.g. calling https://timeapi.io/api/Time/current/zone?timeZone=Europe/Narnia will return a 400 response, but also a body: `"Invalid Timezone"`.

This PR adds a `bool throwRestExceptions` parameter to `Client.execute()` (true by default, so it doesn't break any existing code). If false, the exceptions won't be thrown and a response will be returned.